### PR TITLE
change: name of display short url to `shawty` rather than `wavly`

### DIFF
--- a/main.go
+++ b/main.go
@@ -17,6 +17,7 @@ func main() {
 	// Creating the ServerMux router
 	router := http.NewServeMux()
 
+	// Serving static files
 	router.Handle("GET /static/", http.StripPrefix("/static/", http.FileServer(http.Dir("./static"))))
 
 	// Reading the URLS-SQL schema file

--- a/partial-html/short-link.html
+++ b/partial-html/short-link.html
@@ -1,5 +1,5 @@
 
-<a class="underline text-white" href="/s/{{ .ShortUrl }}">wavly/s/{{ .ShortUrl }}</a>
+<a class="underline text-white" href="/s/{{ .ShortUrl }}">shawty/s/{{ .ShortUrl }}</a>
 <p>Long URL: <a class="underline" href="{{ .OriginalUrl }}">{{ .OriginalUrl }}</a></p>
 
 <a class="my-3 hover:underline w-fit p-3 rounded-md bg-zinc-700" href="/stat/{{ .ShortUrl }}">Total clicks of your short URL</a>

--- a/static/stat.html
+++ b/static/stat.html
@@ -18,7 +18,7 @@
   <div class="w-[56rem] flex flex-col gap-3 my-8 mx-auto">
     <h2 class="text-3xl font-bold font-mono">Total number of clicks</h2>
     <p>The number of clicks from the shortened URL that redirected the user to the destination page.</p>
-    <a class="underline bg-[#292929] font-mono p-2 w-fit rounded-md text-white" href="/s/{{ .ShortUrl }}">wavly/s/{{ .ShortUrl }}</a>
+    <a class="underline bg-[#292929] font-mono p-2 w-fit rounded-md text-white" href="/s/{{ .ShortUrl }}">shawty/s/{{ .ShortUrl }}</a>
       <p class="text-lg font-bold flex gap-3">Original URL : <a class="underline font-mono" href="{{ .OriginalUrl }}">{{ .OriginalUrl }}</a></p>
     <h3 class="font-bold text-xl font-mono">Count: {{ .Count }}</h3>
   </div>


### PR DESCRIPTION
**Change the name of the display short URL link to `shawty/s/{code}` rather than `wavly/s/{code}`** because wavly is an org for creating tools for devs not a link shortener site.