### PR TITLE
Caching Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ package and [Tailwind](https://tailwindcss.com).
 - **URL Click Statistics**:
 Keep track of how many times each shortened URL is accessed.
 
+- **Caching**: Using [Memcached](http://memcached.org/) for faster redirections
+and fewer database calls, by caching the results of redirecting requests to the
+original URL.
+
 - **Input Validation**:
 Checks if the URL is a valid URL schema. It only allows `https://` URLs. And
 also checks if the URL contains a valid
@@ -23,6 +27,7 @@ also checks if the URL contains a valid
 ### Prerequisites
 
 - Go (version 1.20 or higher) - [Download](https://go.dev/doc/install)
+- Memcached - [Download](http://memcached.org/)
 - Turso Account - [Website](https://turso.tech)
 
 ### Installation and Setup
@@ -41,6 +46,10 @@ also checks if the URL contains a valid
 3. **Install the dependencies**:
    ```bash
    go mod tidy
+   ```
+4. **Start the `Memcached` listener**:
+   ```bash
+   memcached # default port is: 11211
    ```
 4. **Run the server**:
    ```bash
@@ -62,13 +71,13 @@ Use the `Makefile` to run/build the web server.
 
 #### Commands
 
-- Run `make server` to start the server in watch mode
-- Run `make tailwind` to watch for tailwind classes
-- Run `make tailmini` to minify the generated tailwind CSS file
+- `make server` to start the server in watch mode
+- `make tailwind` to watch for tailwind classes
+- `make tailmini` to minify the generated tailwind CSS file
 
 ## Contributing
 
-We welcome any contributions to this project! For guidelines on how to contribute, please refer to the [CONTRIBUTING.md](.github/CONTRIBUTING.md) file.
+We welcome any contributions to this project! For major changes, please open an issue first to discuss what you would like to change.
 
 ## LICENSE
 

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require github.com/joho/godotenv v1.5.1
 
 require (
 	github.com/antlr4-go/antlr/v4 v4.13.0 // indirect
+	github.com/bradfitz/gomemcache v0.0.0-20230905024940-24af94b03874 // indirect
 	github.com/coder/websocket v1.8.12 // indirect
 	github.com/mergestat/timediff v0.0.3 // indirect
 	github.com/tursodatabase/libsql-client-go v0.0.0-20240902231107-85af5b9d094d // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/antlr4-go/antlr/v4 v4.13.0 h1:lxCg3LAv+EUK6t1i0y1V6/SLeUi0eKEKdhQAlS8TVTI=
 github.com/antlr4-go/antlr/v4 v4.13.0/go.mod h1:pfChB/xh/Unjila75QW7+VU4TSnWnnk9UTnmpPaOR2g=
+github.com/bradfitz/gomemcache v0.0.0-20230905024940-24af94b03874 h1:N7oVaKyGp8bttX0bfZGmcGkjz7DLQXhAn3DNd3T0ous=
+github.com/bradfitz/gomemcache v0.0.0-20230905024940-24af94b03874/go.mod h1:r5xuitiExdLAJ09PR7vBVENGvp4ZuTBeWTGtxuX3K+c=
 github.com/coder/websocket v1.8.12 h1:5bUXkEPPIbewrnkU8LTCLVaxi4N4J8ahufH2vlo4NAo=
 github.com/coder/websocket v1.8.12/go.mod h1:LNVeNrXQZfe5qhS9ALED3uA+l5pPqvwXg3CKoDBB2gs=
 github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=

--- a/handlers/redirect.go
+++ b/handlers/redirect.go
@@ -11,7 +11,7 @@ import (
 	"github.com/wavly/shawty/database"
 )
 
-func Redirection(w http.ResponseWriter, r *http.Request) {
+func Redirect(w http.ResponseWriter, r *http.Request) {
 	// Get the URL-Path slug "url"
 	code := r.PathValue("code")
 

--- a/handlers/redirect.go
+++ b/handlers/redirect.go
@@ -22,6 +22,7 @@ func Redirect(w http.ResponseWriter, r *http.Request) {
 	// MemcacheD Client
 	mcClient := memcache.New("0.0.0.0:11211")
 
+	// Open a connection to the database
 	db := database.ConnectDB()
 	defer db.Close()
 
@@ -44,15 +45,12 @@ func Redirect(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		log.Println("Cache Miss:", originalUrl)
 		err = mcClient.Set(&memcache.Item{Key: code, Value: []byte(originalUrl)})
 		if err != nil {
 			log.Println("Memcache error when setting the key:", err)
 		}
 	} else if cache != nil && cache.Value != nil { // Check if original URL is in the cache
 		cacheOriginalUrl := string(cache.Value)
-		log.Println("Cashe Hit", cacheOriginalUrl)
-
 		// Redirect to original URL
 		http.Redirect(w, r, cacheOriginalUrl, http.StatusFound)
 

--- a/handlers/redirect.go
+++ b/handlers/redirect.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/bradfitz/gomemcache/memcache"
-	"github.com/wavly/shawty/asserts"
 	"github.com/wavly/shawty/database"
 )
 
@@ -22,7 +21,6 @@ func Redirect(w http.ResponseWriter, r *http.Request) {
 
 	// MemcacheD Client
 	mcClient := memcache.New("0.0.0.0:11211")
-	asserts.NoErr(mcClient.Ping(), "Failed to ping MemcacheD")
 
 	db := database.ConnectDB()
 	defer db.Close()

--- a/handlers/redirection.go
+++ b/handlers/redirection.go
@@ -13,6 +13,11 @@ func Redirection(w http.ResponseWriter, r *http.Request) {
 	// Get the URL-Path slug "url"
 	code := r.PathValue("code")
 
+	if len(code) > 8 {
+		http.Redirect(w, r, "/", http.StatusBadRequest)
+		return
+	}
+
 	db := database.ConnectDB()
 	defer db.Close()
 

--- a/main.go
+++ b/main.go
@@ -45,7 +45,7 @@ func main() {
 	router.HandleFunc("GET /stat/{code}", handlers.Stats)
 
 	// Route to handle redirection
-	router.HandleFunc("GET /s/{code}", handlers.Redirection)
+	router.HandleFunc("GET /s/{code}", handlers.Redirect)
 
 	// API route for shortening the URL
 	router.HandleFunc("POST /shawty", handlers.Shawty)

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"os"
 
+	"github.com/bradfitz/gomemcache/memcache"
 	"github.com/wavly/shawty/asserts"
 	"github.com/wavly/shawty/database"
 	"github.com/wavly/shawty/handlers"
@@ -15,6 +16,10 @@ const PORT string = "1234"
 func main() {
 	// Creating the ServerMux router
 	router := http.NewServeMux()
+
+	// Check if memcache is up
+	mcClient := memcache.New("0.0.0.0:11211")
+	asserts.NoErr(mcClient.Ping(), "Failed to ping MemcacheD")
 
 	// Serving static files
 	router.Handle("GET /static/", http.StripPrefix("/static/", http.FileServer(http.Dir("./static"))))

--- a/sqlc.yaml
+++ b/sqlc.yaml
@@ -1,9 +1,0 @@
-version: "2"
-sql:
-  - engine: "sqlite"
-    queries: "queries"
-    schema: "schema"
-    gen:
-      go:
-        package: "sqlcDB"
-        out: "sqlcGen"


### PR DESCRIPTION
## Caching using Memcached

This pull request adds support for caching HTTP requests, enabling efficient redirection of users to the original URL after caching and fewer calls to the database. It optimizes performance by storing frequently accessed short URLs in `memcached` for quick access.

Here's a simple micro-benchmark using UNIX `time` command:

**Without caching**
```bash
[hamza@archlinux shawty]$ time curl -i http://localhost:1234/s/996e1f71
HTTP/1.1 302 Found
Content-Type: text/html; charset=utf-8
Location: https://github.com
Date: Mon, 16 Sep 2024 04:04:19 GMT
Content-Length: 41

<a href="https://github.com">Found</a>.


real    0m0.968s # 0.968 seconds
user    0m0.004s
sys     0m0.004s
```

**With caching enabled**
```bash
[hamza@archlinux shawty]$ time curl -i http://localhost:1234/s/996e1f71
HTTP/1.1 302 Found
Content-Type: text/html; charset=utf-8
Location: https://github.com
Date: Mon, 16 Sep 2024 04:04:24 GMT
Content-Length: 41

<a href="https://github.com">Found</a>.


real    0m0.408s # 0.408 seconds
user    0m0.004s
sys     0m0.004s
```